### PR TITLE
Export ES6 module via package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/polyfill.js",
   "browser": "dist/polyfill.min.js",
   "jsnext:main": "index.es6.js",
+  "module": "index.es6.js",
   "scripts": {
     "test": "(cd spec/reference-implementation ; npm install && npm run test && cp ../../run-web-platform-tests-on-bundle.js ./ && node --expose_gc run-web-platform-tests-on-bundle.js && rm ./run-web-platform-tests-on-bundle.js)",
     "bundle": "npm-run-all bundle:*",


### PR DESCRIPTION
:wave: cf https://github.com/rollup/rollup/wiki/pkg.module

We need to use this key inside the package.json to be able to use it inside another project.
ex: eslint will throw an error: ` `50:32  error  Unable to resolve path to module 'web-streams-polyfill'  import/no-unresolved`.

You also need to publish the file `index.es6.js` via npm.